### PR TITLE
Fix inline code insertion

### DIFF
--- a/dist/polymer/index.js
+++ b/dist/polymer/index.js
@@ -161,11 +161,10 @@ var modifyInlineIndex = function modifyInlineIndex(buildDir) {
 /**
  * Minify and compress src tags in index files.
  * @param {String} buildDir - Location of build directory.
- * @throws {Error} If no file is compressed.
  */
 var compressInlineIndex = function compressInlineIndex(buildDir) {
   var getInlineTag = function getInlineTag(html) {
-    return (/<script inline src="([\w/]+.js)"><\/script>/g.exec(html)
+    return (/<script inline src="([\w/-]+.js)"><\/script>/.exec(html)
     );
   };
   var index = buildDir + '/_index.html';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Utility fonctions to use in npm script",
   "dependencies": {
     "cpx": "^1.5.0",
-    "inline-source-cli": "^1.2.0",
     "replace-in-file": "^2.5.3",
     "shelljs": "0.7.8",
     "yargs": "9.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udes-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Utility fonctions to use in npm script",
   "dependencies": {
     "cpx": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "cpx": "^1.5.0",
     "replace-in-file": "^2.5.3",
     "shelljs": "0.7.8",
+    "uglify-es": "^3.1.5",
     "yargs": "9.0.1"
   },
   "devDependencies": {

--- a/src/polymer/index.js
+++ b/src/polymer/index.js
@@ -140,7 +140,6 @@ const modifyInlineIndex = (buildDir) => {
 /**
  * Minify and compress src tags in index files.
  * @param {String} buildDir - Location of build directory.
- * @throws {Error} If no file is compressed.
  */
 const compressInlineIndex = (buildDir) => {
   const getInlineTag = html => /<script inline src="([\w/-]+.js)"><\/script>/.exec(html)

--- a/src/polymer/index.js
+++ b/src/polymer/index.js
@@ -140,7 +140,7 @@ const modifyInlineIndex = (buildDir) => {
  * @throws {Error} If no file is compressed.
  */
 const compressInlineIndex = (buildDir) => {
-  const getInlineTag = html => /<script inline src="(.+)">/g.exec(html)
+  const getInlineTag = html => /<script inline src="([\w/]+.js)"><\/script>/g.exec(html)
   const index = `${buildDir}/_index.html`
 
   logger.log(`Minify and compress <src inline> in ${index}...`)
@@ -151,7 +151,7 @@ const compressInlineIndex = (buildDir) => {
 
     while (match) {
       const source = match[1]
-      const code = fs.readFileSync(`${buildDir}${source}`).toString()
+      const code = fs.readFileSync(`${buildDir}/${source}`).toString()
       const minifiedCode = UglifyJS.minify(code).code
 
       html = html.replace(

--- a/src/polymer/index.js
+++ b/src/polymer/index.js
@@ -1,8 +1,7 @@
 import cpx from 'cpx'
 import fs from 'fs'
 import replace from 'replace-in-file'
-import inline from 'inline-source'
-import path from 'path'
+import UglifyJS from 'uglify-es'
 
 import { getArguments, logger } from '../lib/utils'
 
@@ -141,19 +140,32 @@ const modifyInlineIndex = (buildDir) => {
  * @throws {Error} If no file is compressed.
  */
 const compressInlineIndex = (buildDir) => {
+  const getInlineTag = html => /<script inline src="(.+)">/g.exec(html)
   const index = `${buildDir}/_index.html`
 
   logger.log(`Minify and compress <src inline> in ${index}...`)
-  const html = inline.sync(path.resolve(index), {
-    compress: true,
-    rootpath: path.resolve('./'),
-  })
 
-  if (!html) {
-    throw new Error(`${index} not compressed`)
+  try {
+    let html = fs.readFileSync(index).toString()
+    let match = getInlineTag(html)
+
+    while (match) {
+      const source = match[1]
+      const code = fs.readFileSync(`${buildDir}${source}`).toString()
+      const minifiedCode = UglifyJS.minify(code).code
+
+      html = html.replace(
+        `<script inline src="${source}"></script>`,
+        `<script>${minifiedCode}</script>`
+      )
+      match = getInlineTag(html)
+    }
+
+    fs.writeFileSync(index, html)
+    logger.log('Minify and compress <src inline> Ok!')
+  } catch (err) {
+    logger.error(err)
   }
-
-  logger.log('Minify and compress <src inline> Ok!')
 }
 
 /**

--- a/src/polymer/index.js
+++ b/src/polymer/index.js
@@ -143,7 +143,7 @@ const modifyInlineIndex = (buildDir) => {
  * @throws {Error} If no file is compressed.
  */
 const compressInlineIndex = (buildDir) => {
-  const getInlineTag = html => /<script inline src="([\w/]+.js)"><\/script>/g.exec(html)
+  const getInlineTag = html => /<script inline src="([\w/-]+.js)"><\/script>/.exec(html)
   const index = `${buildDir}/_index.html`
 
   logger.log(`Minify and compress <src inline> in ${index}...`)


### PR DESCRIPTION
Le package que nous utilisions ne supportais pas les mots clé de ES6 (tel que `const`) et je n'ai pas trouvé d'autres packages pour l'insertion inline qui fonctionnait correctement. Donc, j'ai simplement écrit une petite fonction qui fait ce que nous voulons directement avec `fs` et des regex.

Nous pourrions potentiellement convertir plusieurs de nos foncitons en une seule et modifier le code nous-même via `fs`. Cela risque d'être plus performant que d'accéder aux fichiers plusieurs fois pour de petites modifs puisque là on écrit et lit le même fichier du disque plusieurs fois de suite ce qui n'est pas très performant. Vous en pensez quoi?