### PR TITLE
Ne pas copier inutilement les fichiers inline

### DIFF
--- a/src/polymer/PolymerBuild.js
+++ b/src/polymer/PolymerBuild.js
@@ -173,18 +173,17 @@ export default class PolymerBuild {
       const source = match[SOURCE_MATCH]
       match = getInlineTag(string)
 
-      if (!fs.existsSync(source)) {
+      if (fs.existsSync(source)) {
+        logger.info(`Inline the ${source} file`)
+        const code = fs.readFileSync(`${source}`).toString()
+
+        string = string.replace(
+          new RegExp(`<script inline(="")? src="${source}"></script>`),
+          `<script>${UglifyJS.minify(code).code}</script>`
+        )
+      } else {
         logger.warn(`The ${source} file could not be inlined`)
-        continue
       }
-
-      logger.info(`Inline the ${source} file`)
-      const code = fs.readFileSync(`${source}`).toString()
-
-      string = string.replace(
-        new RegExp(`<script inline(="")? src="${source}"></script>`),
-        `<script>${UglifyJS.minify(code).code}</script>`
-      )
     }
 
     return string

--- a/src/polymer/PolymerBuild.js
+++ b/src/polymer/PolymerBuild.js
@@ -171,6 +171,7 @@ export default class PolymerBuild {
 
     while (match) {
       const source = match[SOURCE_MATCH]
+      match = getInlineTag(string)
 
       if (!fs.existsSync(source)) {
         logger.warn(`The ${source} file could not be inlined`)
@@ -184,8 +185,6 @@ export default class PolymerBuild {
         new RegExp(`<script inline(="")? src="${source}"></script>`),
         `<script>${UglifyJS.minify(code).code}</script>`
       )
-
-      match = getInlineTag(string)
     }
 
     return string

--- a/src/polymer/test/PolymerBuildTest.js
+++ b/src/polymer/test/PolymerBuildTest.js
@@ -6,7 +6,9 @@ import fs from 'fs'
 
 import PolymerBuild from './../PolymerBuild'
 
-const files = ['index.html', 'index.php', 'script.js']
+const buildFiles = ['index.html', 'index.php' ]
+const files = ['htaccess.sample', 'script.js']
+
 const deleteFolderRecursive = (path) => {
   fs.readdirSync(path).forEach((file) => {
     const currentPath = `${path}/${file}`
@@ -67,11 +69,13 @@ describe('PolymerBuild', () => {
       }
 
       // TODO: Use fs.copyFileSync() after updating to node 8.
-      fs.writeFileSync('htaccess.sample', fs.readFileSync(`${__dirname}/assets/htaccess.sample`))
+      files.forEach((filename) => {
+        fs.writeFileSync(filename, fs.readFileSync(`${__dirname}/assets/${filename}`))
+      })
     })
 
     beforeEach(() => {
-      files.forEach((filename) => {
+      buildFiles.forEach((filename) => {
         // TODO: Use fs.copyFileSync() after updating to node 8.
         fs.writeFileSync(`build/bundled/${filename}`, fs.readFileSync(`${__dirname}/assets/${filename}`))
       })
@@ -79,7 +83,9 @@ describe('PolymerBuild', () => {
 
     after(() => {
       deleteFolderRecursive('build')
-      fs.unlinkSync('htaccess.sample')
+      files.forEach((filename) => {
+        fs.unlinkSync(filename)
+      })
     })
 
     it('should create build for production', () => {


### PR DESCRIPTION
- Suppression du fait qu'il fallait que les fichiers inliné soient dans les builds, on le prend directement à la source.
- Ajout d'un warning si le fichier à inliné n'existe pas.